### PR TITLE
Stac 10417 troubleshooting black topology screen

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -83,6 +83,7 @@
   * [Analytics](use/queries.md)
   * [Alerting](use/alerting.md)
   * [Anomaly Detection with Baselines](use/baselining.md)
+  * [Troubleshooting](use/troubleshooting.md)
 * [Configure](configure/README.md)
   * [Creating a topology manually](configure/how_to_create_manual_topology.md)
   * [Advanced topology queries with STQL](configure/topology_selection_advanced.md)

--- a/use/troubleshooting.md
+++ b/use/troubleshooting.md
@@ -2,12 +2,13 @@
 
 ## Known issues
 
-### ERROR: Resources are low (topology perspective)
+### Error `Resources are low` on topology perspective screen
 
 **Symptom:** Resources are low error message on topology perspective, no topology visualization is displayed.
 
 **Cause:** The GPU load on the machine displaying the StackState UI is too high.
 
-**Possible solution:** To resolve the error and load the topology visualization:
+**Possible solution:**
+To resolve the error and load the topology visualization, try the following:
 * Reload the page.
 * If the error returns or happens consistently, reduce the number of topology visualization windows open to avoid overloading the GPU.

--- a/use/troubleshooting.md
+++ b/use/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Known issues
 
-### Topology perspective - `Resources are low`
+### Topology perspective - `Not enough resources`
 
-**Symptom:** Resources are low message given on topology perspective screen, no topology visualization is displayed.
+**Symptom:** Not enough resources message given on topology perspective screen, no topology visualization is displayed.
 
 **Cause:** The GPU load on the machine displaying the StackState UI is too high.
 
 **Possible solution:**
 To successfully load the topology visualization, try the following:
 * Reload the page.
-* If the error returns or happens consistently, reduce the number of topology visualization windows open to avoid overloading the GPU.
+* If the message returns or appears consistently, reduce the number of topology visualization windows open to avoid overloading the GPU.

--- a/use/troubleshooting.md
+++ b/use/troubleshooting.md
@@ -1,0 +1,13 @@
+# Troubleshooting
+
+## Known issues
+
+### ERROR: Resources are low (topology perspective)
+
+**Symptom:** Resources are low error message on topology perspective, no topology visualization is displayed.
+
+**Cause:** The GPU load on the machine displaying the StackState UI is too high.
+
+**Possible solution:** To resolve the error and load the topology visualization:
+* Reload the page.
+* If the error returns or happens consistently, reduce the number of topology visualization windows open to avoid overloading the GPU.

--- a/use/troubleshooting.md
+++ b/use/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Known issues
 
-### Error `Resources are low` on topology perspective screen
+### Topology perspective - `Resources are low`
 
-**Symptom:** Resources are low error message on topology perspective, no topology visualization is displayed.
+**Symptom:** Resources are low message given on topology perspective, no topology visualization is displayed.
 
 **Cause:** The GPU load on the machine displaying the StackState UI is too high.
 
 **Possible solution:**
-To resolve the error and load the topology visualization, try the following:
+To load the topology visualization, try the following:
 * Reload the page.
 * If the error returns or happens consistently, reduce the number of topology visualization windows open to avoid overloading the GPU.

--- a/use/troubleshooting.md
+++ b/use/troubleshooting.md
@@ -4,11 +4,11 @@
 
 ### Topology perspective - `Resources are low`
 
-**Symptom:** Resources are low message given on topology perspective, no topology visualization is displayed.
+**Symptom:** Resources are low message given on topology perspective screen, no topology visualization is displayed.
 
 **Cause:** The GPU load on the machine displaying the StackState UI is too high.
 
 **Possible solution:**
-To load the topology visualization, try the following:
+To successfully load the topology visualization, try the following:
 * Reload the page.
 * If the error returns or happens consistently, reduce the number of topology visualization windows open to avoid overloading the GPU.


### PR DESCRIPTION
Adds troubleshooting page to the 'use' section for 'resources are low' message