### PR TITLE
STAC-11738 How to configure self-signed certificates (4.2.4 release)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -141,6 +141,7 @@
     * [Roles](configure/security/rbac/rbac_roles.md)
     * [Scopes](configure/security/rbac/rbac_scopes.md)
     * [Subjects](configure/security/rbac/rbac_subjects.md)
+  * [Self-signed certificates](configure/security/self-signed-certificates.md)
   * [Secrets management](configure/security/secrets_management.md)
   * [Set up a security backend for Linux](configure/security/set_up_a_security_backend_for_linux.md)
   * [Set up a security backend for Windows](configure/security/set_up_a_security_backend_for_windows.md)

--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -5,13 +5,15 @@ kind: Documentation
 
 # Self-signed certificates
 
-StackState has several points of interaction with external systems, for example event handlers can call out to webhooks in other systems while plugins can retrieve data from external systems like Splunk or Elasticsearch. StackState will not be able to communicate witht these systems when they are secured with TLS using a self-signed certificate or a certificate that is not by default trusted by the JVM.
+StackState has several points of interaction with external systems, for example event handlers can call out to webhooks in other systems while plugins can retrieve data from external systems like Splunk or Elasticsearch. With the default configuration, StackState will not be able to communicate with these systems when they are secured with TLS using a self-signed certificate or a certificate that is not by default trusted by the JVM.
 
 To mitigate this StackState allows configuration of a custom trust store.
 
 ## Creating a custom trust store
 
-You need an installed JVM (the operating system you're on doesn't matter) to be able to create a new trust store. You also need to have the certificate available, if you don't have that [here](#retrieve-certificate-via-the-browser) is a way how to get it.
+To convert an existing TLS certificate file to the format that is needed by StackState, you'll need to use the keytool tool and the cacerts file that both are included in the Java Virtual Machine installation. You can run this on any machine, regardless of the type of operating system.
+
+You also need to have the certificate available, if you don't have that, [retrieve it via the browser](#retrieve-certificate-via-the-browser).
 
 With the JVM installed and the certificate saved as a file `site.cert` you can create a new trust store by taking the JVM's trust store and adding the extra certificate.
 
@@ -20,7 +22,7 @@ With the JVM installed and the certificate saved as a file `site.cert` you can c
    ```bash
    keytool -import -keystore custom_cacerts -alias <a-name-for-the-certificate>  -file site.cert
    ```
-   The alias needs to be a unique alias for the certificate, for example the domain name itself without any dots. Keytool will ask for a password, the JVM default password is `changeit`.
+   The alias needs to be a unique alias for the certificate, for example the domain name itself without any dots. Keytool will ask for a password. The password usually is `changeit`, the JVM default.
 
 The `custom_cacerts` store file will now include the `site.cert` certificate. You can verify that by searching for the alias in the output of
 
@@ -38,7 +40,6 @@ helm upgrade \
   --install \
   --namespace stackstate \
   --values values.yaml \
-  --values authentication.yaml \
   --set-file 'stackstate.java.trustStore'=custom_cacerts \
   --set 'stackstate.java.trustStorePassword'=changeit \
 stackstate \

--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -16,9 +16,17 @@ You need an installed JVM (the operating system you're on doesn't matter) to be 
 With the JVM installed and the certificate saved as a file `site.cert` you can create a new trust store by taking the JVM's trust store and adding the extra certificate.
 
 1. Copy the `cacerts` file from `$JAVA_HOME/lib/security/cacerts` to `custom_cacerts` with `$JAVA_HOME` the location of your Java installation. This environment variable is normally set by the Java installation.
-2. Add the extra certificate(s) with `keytool -import -keystore custom_cacerts -alias <a-name-for-the-certificate>  -file site.cert`. Here you should provide a unique alias for the certificate (for example the domain name itself without any dots). Keytool will ask for a password, the JVM default is `changeit`.
+2. Add the extra certificate(s) with 
+   ```bash
+   keytool -import -keystore custom_cacerts -alias <a-name-for-the-certificate>  -file site.cert
+   ```
+   The alias needs to be a unique alias for the certificate, for example the domain name itself without any dots. Keytool will ask for a password, the JVM default password is `changeit`.
 
-The `custom_cacerts` store will now include the `site.cert` certificate. You can verify that with `keytool -list -keystore custom_cacerts` and search for the alias specified in step 2.
+The `custom_cacerts` store file will now include the `site.cert` certificate. You can verify that by searching for the alias in the output of
+
+```bash
+keytool -list -keystore custom_cacerts
+```
 
 ## Using the custom trust store
 
@@ -49,7 +57,7 @@ For a Linux installation the trust store and password need to be added to the JV
 
 Copy the new trust store into `/opt/stackstate/etc`. Now edit (or create if it does not yet exist) `/opt/stackstate/etc/processmanager/processmanager-properties-overrides.conf` and add this line:
 
-```
+```javascript
 properties.sts-jvm-args = "-Djavax.net.ssl.trustStore=/opt/stackstate/etc/custom_cacerts -Djavax.net.ssl.trustStoreType=jks -Djavax.net.ssl.trustStorePassword=changeit"
 ```
 

--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -11,24 +11,49 @@ To mitigate this StackState allows configuration of a custom trust store.
 
 ## Creating a custom trust store
 
-To convert an existing TLS certificate file to the format that is needed by StackState, you'll need to use the keytool tool and the cacerts file that both are included in the Java Virtual Machine installation. You can run this on any machine, regardless of the type of operating system.
+You need to have the custom TLS certificate available, if you don't have that, [retrieve it via the browser](#retrieve-certificate-via-the-browser).
 
-You also need to have the certificate available, if you don't have that, [retrieve it via the browser](#retrieve-certificate-via-the-browser).
+To convert an existing TLS certificate file to the format that is needed by StackState, you'll need to use the keytool tool and the cacerts file that both are included in the Java Virtual Machine (JVM) installation. You can run this on any machine, regardless of the type of operating system. If you don't have the JVM installed on your computer you can also use a JVM docker image instead.
+
+### Using the Java Virtual Machine installed on your computer
 
 With the JVM installed and the certificate saved as a file `site.cert` you can create a new trust store by taking the JVM's trust store and adding the extra certificate.
 
-1. Copy the `cacerts` file from `$JAVA_HOME/lib/security/cacerts` to `custom_cacerts` with `$JAVA_HOME` the location of your Java installation. This environment variable is normally set by the Java installation.
-2. Add the extra certificate(s) with 
+1. Create a working directory `workdir` into which you copy the certificate file `site.cert`.
+2. Change directory to the workdir and make a copy of the `cacerts` from your Java installation. `$JAVA_HOME` is an environment varialbe that contains the location of your Java installation. This is normally set when installing Java.
+   ```bash
+   cd workdir
+   cp $JAVA_HOME/lib/security/cacerts ./custom_cacerts
+   ```
+3. Run the following keytool command to add the certificate. The required password is `changeit`. The alias needs to be a unique alias for the certificate, for example the domain name itself without any dots.
    ```bash
    keytool -import -keystore custom_cacerts -alias <a-name-for-the-certificate>  -file site.cert
    ```
-   The alias needs to be a unique alias for the certificate, for example the domain name itself without any dots. Keytool will ask for a password. The password usually is `changeit`, the JVM default.
+4. The `custom_cacerts` store file will now include the `site.cert` certificate. You can verify that by searching for the alias in the output of
+   ```bash
+   keytool -list -keystore custom_cacerts
+   ```
 
-The `custom_cacerts` store file will now include the `site.cert` certificate. You can verify that by searching for the alias in the output of
+### Using the Java Virtual Machine from a Docker image
 
-```bash
-keytool -list -keystore custom_cacerts
-```
+1. Create a working directory `workdir` into which you copy the certificate file `site.cert`. 
+2. Start the Java docker container with the workdir mounted as a volume so it can be accessed:
+   ```bash
+   docker run -it -v `pwd`/workdir:/workdir  adoptopenjdk:11 bash
+   ```
+3. Change directory to the workdir and make a copy of the `cacerts` file in your workdir:
+   ```bash
+   cd /workdir
+   cp $JAVA_HOME/lib/security/cacerts ./custom_cacerts
+   ```
+4. Run the following keytool command to add the certificate. The required password is `changeit`. The alias needs to be a unique alias for the certificate, for example the domain name itself without any dots.
+   ```bash
+   keytool -import -keystore custom_cacerts -alias <a-name-for-the-certificate>  -file site.cert
+   ```
+5. The `custom_cacerts` store file will now include the `site.cert` certificate. You can verify that by searching for the alias in the output of
+    ```bash
+    keytool -list -keystore custom_cacerts
+    ```
 
 ## Using the custom trust store
 

--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -91,7 +91,7 @@ For a Linux installation, the trust store and password need to be added to the J
 
 3. Finally, restart StackState to use the new settings:
     ```
-    systemcl restart stackstate
+    systemctl restart stackstate
     ```
 
 ## Retrieve certificate via the browser
@@ -103,5 +103,5 @@ The certificate can be directly downloaded from the Chrome browser. The steps in
 3. Click on **Certificate**.
 4. Select **Details**.
 5. Select **Export**.
-6. Save using the default export file type (Base64 ASCII encoded)
+6. Save using the default export file type (Base64 ASCII encoded).
   

--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -12,7 +12,7 @@ You need to have the custom TLS certificate available. If you don't have that, y
 
 To convert an existing TLS certificate file to the format that is needed by StackState, you will need to use the keytool tool and the `cacerts` file that are included in the JVM (Java Virtual Machine) installation. You can run this on any machine, regardless of the type of operating system. 
 
-If you don't have the JVM installed on your computer, you can also [use a JVM docker image](#docker-java-virtual-machine) instead.
+If you don't have the JVM installed on your computer, you can also [use a JVM docker image](#using-a-docker-jvm) instead.
 
 ### Using an installed JVM
 
@@ -33,7 +33,7 @@ With the JVM installed on your computer and the certificate saved as a file `sit
    keytool -list -keystore custom_cacerts
    ```
 
-### Using Docker JVM
+### Using a Docker JVM
 
 If you do not have JVM installed on your computer, you can use a JVM Docker image. The certificate should be retrieved and saved as a file `site.cert`.
 

--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -96,12 +96,12 @@ For a Linux installation, the trust store and password need to be added to the J
 
 ## Retrieve certificate via the browser
 
-The certificate can be directly downloaded from the Chrome browser. The steps involved may be slightly different depending on the version you are using:
+The certificate can be directly downloaded from the Chrome browser. The steps involved may vary slightly depending on the version you are using:
 
-1. Navigate to the URL you need the certificate from
-2. Click on the padlock icon in the location bar
-3. Click on "Certificate"
-4. Select "Details"
-5. Select "Export" 
+1. Navigate to the URL you need the certificate from.
+2. Click on the padlock icon in the location bar.
+3. Click on **Certificate**.
+4. Select **Details**.
+5. Select **Export**.
 6. Save using the default export file type (Base64 ASCII encoded)
   

--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -14,7 +14,7 @@ To convert an existing TLS certificate file to the format that is needed by Stac
 
 If you don't have the JVM installed on your computer, you can also [use a JVM docker image](#docker-java-virtual-machine) instead.
 
-### With Java Virtual Machine installed
+### Using an installed JVM
 
 With the JVM installed on your computer and the certificate saved as a file `site.cert`, you can create a new trust store by taking the JVM's trust store and adding the extra certificate.
 
@@ -33,7 +33,7 @@ With the JVM installed on your computer and the certificate saved as a file `sit
    keytool -list -keystore custom_cacerts
    ```
 
-### Docker Java Virtual Machine
+### Using Docker JVM
 
 If you do not have JVM installed on your computer, you can use a JVM Docker image. The certificate should be retrieved and saved as a file `site.cert`.
 

--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -1,26 +1,25 @@
----
-title: Self-signed certificates
-kind: Documentation
----
-
 # Self-signed certificates
+
+## Overview
 
 StackState has several points of interaction with external systems, for example event handlers can call out to webhooks in other systems while plugins can retrieve data from external systems like Splunk or Elasticsearch. With the default configuration, StackState will not be able to communicate with these systems when they are secured with TLS using a self-signed certificate or a certificate that is not by default trusted by the JVM.
 
-To mitigate this StackState allows configuration of a custom trust store.
+To mitigate this, StackState allows configuration of a custom trust store.
 
-## Creating a custom trust store
+## Create a custom trust store
 
-You need to have the custom TLS certificate available, if you don't have that, [retrieve it via the browser](#retrieve-certificate-via-the-browser).
+You need to have the custom TLS certificate available. If you don't have that, you will need to [retrieve it via the browser](#retrieve-certificate-via-the-browser).
 
-To convert an existing TLS certificate file to the format that is needed by StackState, you'll need to use the keytool tool and the cacerts file that both are included in the Java Virtual Machine (JVM) installation. You can run this on any machine, regardless of the type of operating system. If you don't have the JVM installed on your computer you can also use a JVM docker image instead.
+To convert an existing TLS certificate file to the format that is needed by StackState, you will need to use the keytool tool and the `cacerts` file that are included in the JVM (Java Virtual Machine) installation. You can run this on any machine, regardless of the type of operating system. 
 
-### Using the Java Virtual Machine installed on your computer
+If you don't have the JVM installed on your computer, you can also [use a JVM docker image](#docker-java-virtual-machine) instead.
 
-With the JVM installed and the certificate saved as a file `site.cert` you can create a new trust store by taking the JVM's trust store and adding the extra certificate.
+### With Java Virtual Machine installed
 
-1. Create a working directory `workdir` into which you copy the certificate file `site.cert`.
-2. Change directory to the workdir and make a copy of the `cacerts` from your Java installation. `$JAVA_HOME` is an environment varialbe that contains the location of your Java installation. This is normally set when installing Java.
+With the JVM installed on your computer and the certificate saved as a file `site.cert`, you can create a new trust store by taking the JVM's trust store and adding the extra certificate.
+
+1. Create a working directory `workdir` and copy the certificate file `site.cert` to this directory.
+2. Change directory to the `workdir` and make a copy of the `cacerts` file from your Java installation. `$JAVA_HOME` is an environment variable that contains the location of your Java installation. This is normally set when installing Java.
    ```bash
    cd workdir
    cp $JAVA_HOME/lib/security/cacerts ./custom_cacerts
@@ -34,14 +33,16 @@ With the JVM installed and the certificate saved as a file `site.cert` you can c
    keytool -list -keystore custom_cacerts
    ```
 
-### Using the Java Virtual Machine from a Docker image
+### Docker Java Virtual Machine
 
-1. Create a working directory `workdir` into which you copy the certificate file `site.cert`. 
-2. Start the Java docker container with the workdir mounted as a volume so it can be accessed:
+If you do not have JVM installed on your computer, you can use a JVM Docker image. The certificate should be retrieved and saved as a file `site.cert`.
+
+1. Create a working directory `workdir` and copy the certificate file `site.cert` to this directory.
+2. Start the Java Docker container with the `workdir` mounted as a volume so it can be accessed:
    ```bash
    docker run -it -v `pwd`/workdir:/workdir  adoptopenjdk:11 bash
    ```
-3. Change directory to the workdir and make a copy of the `cacerts` file in your workdir:
+3. Change directory to the `workdir` and make a copy of the `cacerts` file:
    ```bash
    cd /workdir
    cp $JAVA_HOME/lib/security/cacerts ./custom_cacerts
@@ -55,10 +56,11 @@ With the JVM installed and the certificate saved as a file `site.cert` you can c
     keytool -list -keystore custom_cacerts
     ```
 
-## Using the custom trust store
+## Use a custom trust store
 
 ### Kubernetes
-For Kubernetes installations the trust store and the password can be specified as values. Since the store is a file it can only be specified from the helm command line. We specify the password value in the same way, but it could also be provided via a `values.yaml` file.
+
+For Kubernetes installations, the trust store and the password can be specified as values. The trust store can only be specified from the helm command line as it is a file. We specify the password value in the same way, but it could also be provided via a `values.yaml` file.
 
 ```bash
 helm upgrade \
@@ -79,22 +81,22 @@ stackstate/stackstate
 {% endhint %}
 
 ### Linux
-For a Linux installation the trust store and password need to be added to the JVM command line used to start the StackState server process.
+For a Linux installation, the trust store and password need to be added to the JVM command line used to start the StackState server process.
 
-Copy the new trust store into `/opt/stackstate/etc`. Now edit (or create if it does not yet exist) `/opt/stackstate/etc/processmanager/processmanager-properties-overrides.conf` and add this line:
+1. Copy the new trust store into `/opt/stackstate/etc`. 
+2. Edit (or create if it does not yet exist) the file `/opt/stackstate/etc/processmanager/processmanager-properties-overrides.conf` and add this line:
+    ```javascript
+    properties.sts-jvm-args = "-Djavax.net.ssl.trustStore=/opt/stackstate/etc/custom_cacerts -Djavax.net.ssl.trustStoreType=jks -Djavax.net.ssl.trustStorePassword=changeit"
+    ```
 
-```javascript
-properties.sts-jvm-args = "-Djavax.net.ssl.trustStore=/opt/stackstate/etc/custom_cacerts -Djavax.net.ssl.trustStoreType=jks -Djavax.net.ssl.trustStorePassword=changeit"
-```
-
-Finally restart StackState to use the new settings:
-```
-systemcl restart stackstate
-```
+3. Finally, restart StackState to use the new settings:
+    ```
+    systemcl restart stackstate
+    ```
 
 ## Retrieve certificate via the browser
 
-With the Chrome browser it is possible to download the certificate directly from the browser. Due to different versions the steps involved may be slightly different in your case.
+The certificate can be directly downloaded from the Chrome browser. The steps involved may be slightly different depending on the version you are using:
 
 1. Navigate to the URL you need the certificate from
 2. Click on the padlock icon in the location bar

--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -1,0 +1,71 @@
+---
+title: Self-signed certificates
+kind: Documentation
+---
+
+# Self-signed certificates
+
+StackState has several points of interaction with external systems, for example event handlers can call out to webhooks in other systems while plugins can retrieve data from external systems like Splunk or Elasticsearch. StackState will not be able to communicate witht these systems when they are secured with TLS using a self-signed certificate or a certificate that is not by default trusted by the JVM.
+
+To mitigate this StackState allows configuration of a custom trust store.
+
+## Creating a custom trust store
+
+You need an installed JVM (the operating system you're on doesn't matter) to be able to create a new trust store. You also need to have the certificate available, if you don't have that [here](#retrieve-certificate-via-the-browser) is a way how to get it.
+
+With the JVM installed and the certificate saved as a file `site.cert` you can create a new trust store by taking the JVM's trust store and adding the extra certificate.
+
+1. Copy the `cacerts` file from `$JAVA_HOME/lib/security/cacerts` to `custom_cacerts` with `$JAVA_HOME` the location of your Java installation. This environment variable is normally set by the Java installation.
+2. Add the extra certificate(s) with `keytool -import -keystore custom_cacerts -alias <a-name-for-the-certificate>  -file site.cert`. Here you should provide a unique alias for the certificate (for example the domain name itself without any dots). Keytool will ask for a password, the JVM default is `changeit`.
+
+The `custom_cacerts` store will now include the `site.cert` certificate. You can verify that with `keytool -list -keystore custom_cacerts` and search for the alias specified in step 2.
+
+## Using the custom trust store
+
+### Kubernetes
+For Kubernetes installations the trust store and the password can be specified as values. Since the store is a file it can only be specified from the helm command line. We specify the password value in the same way, but it could also be provided via a `values.yaml` file.
+
+```bash
+helm upgrade \
+  --install \
+  --namespace stackstate \
+  --values values.yaml \
+  --values authentication.yaml \
+  --set-file 'stackstate.java.trustStore'=custom_cacerts \
+  --set 'stackstate.java.trustStorePassword'=changeit \
+stackstate \
+stackstate/stackstate
+```
+
+{% hint style="info" %}
+**Note:**
+* The first run of the helm upgrade command will result in pods restarting, which may cause a short interruption of availability.
+* Include these arguments on every `helm upgrade` run.
+* The password and trust store are stored as a Kubernetes secret.
+{% endhint %}
+
+### Linux
+For a Linux installation the trust store and password need to be added to the JVM command line used to start the StackState server process.
+
+Copy the new trust store into `/opt/stackstate/etc`. Now edit (or create if it does not yet exist) `/opt/stackstate/etc/processmanager/processmanager-properties-overrides.conf` and add this line:
+
+```
+properties.sts-jvm-args = "-Djavax.net.ssl.trustStore=/opt/stackstate/etc/custom_cacerts -Djavax.net.ssl.trustStoreType=jks -Djavax.net.ssl.trustStorePassword=changeit"
+```
+
+Finally restart StackState to use the new settings:
+```
+systemcl restart stackstate
+```
+
+## Retrieve certificate via the browser
+
+With the Chrome browser it is possible to download the certificate directly from the browser. Due to different versions the steps involved may be slightly different in your case.
+
+1. Navigate to the URL you need the certificate from
+2. Click on the padlock icon in the location bar
+3. Click on "Certificate"
+4. Select "Details"
+5. Select "Export" 
+6. Save using the default export file type (Base64 ASCII encoded)
+  


### PR DESCRIPTION
Part of the StackState 4.2.4 release

This supports a custom trust store that can be used for connecting to applications that use self-signed certificates.