### PR TITLE
STAC-11679 CPU limit and requests changes

### DIFF
--- a/setup/installation/kubernetes_install/development_setup.md
+++ b/setup/installation/kubernetes_install/development_setup.md
@@ -1,11 +1,15 @@
 # Development setup
 
+{% hint style="danger" %}
+The test and micro\_test deployments described on this page are not suitable for bigger workloads. They are not supported for production usage.
+{% endhint %}
+
 The standard Kubernetes deployment of StackState is a production ready setup with many processes running multiple replicas. For development and testing purposes, it can be desirable to run StackState with lower resource requirements. Several example `values.yaml` files are provided in the [Helm chart repository](https://github.com/StackVista/helm-charts/tree/master/stable/stackstate/installation/examples):
 
-* `test_values.yaml` sets the replica count for all services to 1, this effectively reduces the number of required nodes from 7 to 3.
+* `test_values.yaml` sets the replica count for all services to 1, this effectively reduces the number of required nodes to 3.
 * `micro_test_values.yaml` goes even further and also reduces the memory footprint of most services, thereby making it possible to run StackState within about 16GB of memory.
 
-Note that the generated `values.yaml` should also still be included on the Helm command line, e.g.:
+Note that the generated `values.yaml` should also still be included on the Helm command line, for example:
 
 ```text
 helm upgrade \
@@ -16,8 +20,4 @@ helm upgrade \
 stackstate \
 stackstate/stackstate
 ```
-
-{% hint style="danger" %}
-Both the test and micro\_test deployments are not suitable for bigger workloads. They are not supported for production usage.
-{% endhint %}
 

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -10,9 +10,9 @@ For a list of all docker images used see the [image overview](installation/kuber
 
 For a standard deployment, the StackState Helm chart will deploy storage services in a redundant setup with 3 instances of each service. The nodes required for different environments:
 
-* **Virtual machines:** 7 nodes with `16GB memory`, `4 vCPUs`
-* **Amazon EKS:** 7 instances of type `m5.xlarge` or `m4.xlarge`
-* **Azure AKS:** 7 instances of type `D4s v3` or `D4as V4` \(Intel or AMD CPUs\)
+* **Virtual machines:** 9 nodes with `16GB memory`, `4 vCPUs`
+* **Amazon EKS:** 9 instances of type `m5.xlarge` or `m4.xlarge`
+* **Azure AKS:** 9 instances of type `D4s v3` or `D4as V4` \(Intel or AMD CPUs\)
 
 ### Storage
 

--- a/setup/upgrade-stackstate/version-specific-upgrade-instructions.md
+++ b/setup/upgrade-stackstate/version-specific-upgrade-instructions.md
@@ -16,11 +16,31 @@ This page provides specific instructions for upgrading to each currently support
 
 ## Upgrade instructions
 
-### Upgrade to v4.2.x
+### Upgrade to v4.3.x
 
 {% tabs %}
 {% tab title="Kubernetes" %}
 
+#### v4.3.0
+
+For the Kubernetes installation of StackState 4.3.0 CPU limits have been added to all pods. If you have customized any of the CPU requests in your `values.yaml` you most likely will now need to also set the CPU limit for the same pod(s). 
+
+At the same time CPU limits and requests have been re-evaluated and increased where needed for stable operation resulting in a change in the number of [required nodes from 7 to 9](../requirements.md).
+
+{% endtab %}
+
+{% tab title="Linux" %}
+
+#### v4.3.0
+
+No manual action needed.
+
+{% endtab %}
+{% endtabs %}
+### Upgrade to v4.2.x
+
+{% tabs %}
+{% tab title="Kubernetes" %}
 ####  v4.2.3
 Authentication configuration for the Kubernetes Helm chart has been made easier for this release. If your StackState authentication was customized, it will need to be updated. To verify this, check if there is a `stackstate.server.config` or `stackstate.api.config` value that contains an `authentication` section in the `values.yaml` file(s) used for installation.
 


### PR DESCRIPTION
Requirements changed because of chagnes to chart defaults. This also adds an upgrade note for customers that may have manually tweaked some cpu requests. 