### PR TITLE
Fix port StackState UI 

### DIFF
--- a/setup/installation/initial_run_guide.md
+++ b/setup/installation/initial_run_guide.md
@@ -39,7 +39,7 @@ To access the StackState UI:
 
 The StackState UI can be accessed using the `STACKSTATE_BASE_URL` specified during installation:
 
-`https://STACKSTATE_BASE_URL:7077`
+`https://STACKSTATE_BASE_URL:7070`
 {% endtab %}
 
 {% tab title="Openshift" %}


### PR DESCRIPTION
Fixed a url where the port indicated for StackState UI was 7077 instead of 7070