### PR TITLE
Update IAM policy, fix proxy and agent config

### DIFF
--- a/stackpacks/integrations/aws/aws-policies.md
+++ b/stackpacks/integrations/aws/aws-policies.md
@@ -68,9 +68,10 @@ For an AWS agent running on an EC2 instance:
     "Statement": [
         {
             "Action": [
-                "cloudformation:GetTemplate"
+                "cloudtrail:LookupEvents",
+                "iam:ListAccountAliases"
             ],
-            "Resource": "arn:aws:cloudformation:*:${AccountId}:stack/stackstate-resources/*",
+            "Resource": "*",
             "Effect": "Allow",
             "Sid": "SelfAccess"
         },
@@ -85,37 +86,13 @@ For an AWS agent running on an EC2 instance:
         },
         {
             "Action": [
-                "cloudtrail:LookupEvents",
-                "events:DescribeApiDestination",
-                "events:DescribeArchive",
-                "events:DescribeConnection",
-                "events:DescribeEventBus",
-                "events:DescribeReplay",
-                "events:DescribeRule",
-                "events:ListApiDestinations",
-                "events:ListArchives",
-                "events:ListConnections",
-                "events:ListEventBuses",
-                "events:ListEventSources",
-                "events:ListReplays",
-                "events:ListRules",
-                "events:ListTagsForResource",
-                "events:ListTargetsByRule",
-                "iam:GetAccountAuthorizationDetails"
-            ],
-            "Resource": "*",
-            "Effect": "Allow",
-            "Sid": "EventsAccess"
-        },
-        {
-            "Action": [
-                "s3:ListBucket",
+                "s3:DeleteObject",
                 "s3:GetObject",
                 "s3:GetObjectVersion",
-                "s3:DeleteObject"
+                "s3:ListBucket"
             ],
             "Resource": [
-                "aws:aws:s3:::stackstate-logs-${AccountId}",
+                "arn:aws:s3:::stackstate-logs-${AccountId}",
                 "arn:aws:s3:::stackstate-logs-${AccountId}/*"
             ],
             "Effect": "Allow",
@@ -125,68 +102,35 @@ For an AWS agent running on an EC2 instance:
             "Action": [
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceTypes",
-                "ec2:DescribeIdFormat",
-                "ec2:DescribeReservedInstancesOfferings",
-                "ec2:DescribeFleetInstances",
-                "ec2:DescribeVpcEndpointServiceConfigurations",
-                "ec2:DescribePrefixLists",
-                "ec2:GetReservedInstancesExchangeQuote",
-                "ec2:DescribeInstanceCreditSpecifications",
-                "ec2:DescribeVolumeAttribute",
-                "ec2:DescribeImportSnapshotTasks",
-                "ec2:DescribeVpcEndpointServicePermissions",
-                "ec2:DescribeScheduledInstances",
-                "ec2:DescribeImageAttribute",
-                "ec2:DescribeFleets",
-                "ec2:DescribeElasticGpus",
-                "ec2:DescribeReservedInstancesModifications",
-                "ec2:DescribeVpcEndpoints",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeVpnGateways",
-                "ec2:DescribeFleetHistory",
-                "ec2:DescribeAddresses",
-                "ec2:DescribePrincipalIdFormat",
-                "ec2:DescribeInstanceAttribute",
-                "ec2:DescribeFlowLogs",
-                "ec2:DescribeRegions",
-                "ec2:DescribeDhcpOptions",
-                "ec2:DescribeSpotPriceHistory",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeNetworkInterfaceAttribute",
-                "ec2:DescribeVpcEndpointConnections",
-                "ec2:DescribeInstanceStatus",
-                "ec2:DescribeHostReservations",
-                "ec2:DescribeIamInstanceProfileAssociations",
-                "ec2:DescribeTags",
-                "ec2:DescribeLaunchTemplateVersions",
-                "ec2:DescribeBundleTasks",
-                "ec2:DescribeClassicLinkInstances",
-                "ec2:DescribeIdentityIdFormat",
-                "ec2:DescribeImportImageTasks",
-                "ec2:DescribeNatGateways",
-                "ec2:DescribeCustomerGateways",
-                "ec2:DescribeVpcEndpointConnectionNotifications",
                 "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSpotFleetRequests",
-                "ec2:DescribeHosts",
-                "ec2:DescribeImages",
-                "ec2:DescribeFpgaImages",
-                "ec2:DescribeSpotFleetInstances",
-                "ec2:DescribeSecurityGroupReferences",
+                "ec2:DescribeSubnets",
                 "ec2:DescribeVpcs",
-                "autoscaling:Describe*",
-                "ec2:DescribeVpnGateways",
-                "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeTargetGroups",
-                "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DescribeInstanceHealth",
-                "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeListeners"
+                "ec2:DescribeVpnGateways"
             ],
             "Resource": "*",
             "Effect": "Allow",
             "Sid": "Ec2Access"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:DescribeInstanceHealth",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetHealth"
+            ],
+            "Resource": "*",
+            "Effect": "Allow",
+            "Sid": "LoadBalancingAccess"
+        },
+        {
+            "Action": [
+                "autoscaling:DescribeAutoScalingGroups"
+            ],
+            "Resource": "*",
+            "Effect": "Allow",
+            "Sid": "AutoScalingAccess"
         },
         {
             "Action": [
@@ -198,24 +142,29 @@ For an AWS agent running on an EC2 instance:
         },
         {
             "Action": [
-                "ecs:ListAttributes",
-                "ecs:ListTasks",
-                "ecs:ListContainerInstances",
-                "ecs:DescribeContainerInstances",
-                "ecs:DescribeTasks",
                 "ecs:DescribeClusters",
-                "ecs:ListServices",
-                "ecs:ListTaskDefinitionFamilies",
+                "ecs:DescribeContainerInstances",
                 "ecs:DescribeServices",
-                "ecs:DescribeTaskDefinition",
-                "ecs:ListTaskDefinitions",
+                "ecs:DescribeTasks",
                 "ecs:ListClusters",
-                "servicediscovery:List*",
-                "servicediscovery:Get*"
+                "ecs:ListContainerInstances",
+                "ecs:ListServices",
+                "ecs:ListTasks"
             ],
             "Resource": "*",
             "Effect": "Allow",
             "Sid": "EcsAccess"
+        },
+        {
+            "Action": [
+                "servicediscovery:GetNamespace",
+                "servicediscovery:GetService",
+                "servicediscovery:ListInstances",
+                "servicediscovery:ListServices"
+            ],
+            "Resource": "*",
+            "Effect": "Allow",
+            "Sid": "ServiceDiscoveryAccess"
         },
         {
             "Action": [
@@ -225,16 +174,14 @@ For an AWS agent running on an EC2 instance:
             ],
             "Resource": "*",
             "Effect": "Allow",
-            "Sid": "Accessfirehose"
+            "Sid": "FirehoseAccess"
         },
         {
             "Action": [
-                "s3:ListBucketByTags",
-                "s3:ListBucket",
                 "s3:GetBucketNotification",
-                "s3:GetBucketLocation",
                 "s3:GetBucketTagging",
-                "s3:ListAllMyBuckets"
+                "s3:ListAllMyBuckets",
+                "s3:ListBucket"
             ],
             "Resource": "*",
             "Effect": "Allow",
@@ -242,15 +189,8 @@ For an AWS agent running on an EC2 instance:
         },
         {
             "Action": [
-                "rds:ListTagsForResource",
-                "rds:DescribeDBParameters",
-                "rds:DescribeDBParameterGroups",
                 "rds:DescribeDBClusters",
-                "rds:DescribeDBInstances",
-                "rds:DescribeEngineDefaultClusterParameters",
-                "rds:DescribeEngineDefaultParameters",
-                "rds:DescribeEventCategories",
-                "rds:DescribeAccountAttributes"
+                "rds:DescribeDBInstances"
             ],
             "Resource": "*",
             "Effect": "Allow",
@@ -258,13 +198,13 @@ For an AWS agent running on an EC2 instance:
         },
         {
             "Action": [
+                "route53:GetHostedZone",
+                "route53:ListHostedZones",
+                "route53:ListResourceRecordSets",
+                "route53:ListTagsForResource",
                 "route53domains:GetDomainDetail",
                 "route53domains:ListDomains",
-                "route53domains:ListTagsForDomain",
-                "route53:ListHostedZones",
-                "route53:ListTagsForResource",
-                "route53:GetHostedZone",
-                "route53:ListResourceRecordSets"
+                "route53domains:ListTagsForDomain"
             ],
             "Resource": "*",
             "Effect": "Allow",
@@ -276,8 +216,7 @@ For an AWS agent running on an EC2 instance:
                 "lambda:ListAliases",
                 "lambda:ListEventSourceMappings",
                 "lambda:ListFunctions",
-                "lambda:ListTags",
-                "lambda:ListVersionsByFunction"
+                "lambda:ListTags"
             ],
             "Resource": "*",
             "Effect": "Allow",
@@ -296,9 +235,8 @@ For an AWS agent running on an EC2 instance:
         },
         {
             "Action": [
-                "sqs:ListQueues",
-                "sqs:GetQueueUrl",
                 "sqs:GetQueueAttributes",
+                "sqs:ListQueues",
                 "sqs:ListQueueTags"
             ],
             "Resource": "*",
@@ -308,8 +246,8 @@ For an AWS agent running on an EC2 instance:
         {
             "Action": [
                 "dynamodb:DescribeTable",
-                "dynamodb:ListTagsOfResource",
-                "dynamodb:ListTables"
+                "dynamodb:ListTables",
+                "dynamodb:ListTagsOfResource"
             ],
             "Resource": "*",
             "Effect": "Allow",
@@ -318,8 +256,8 @@ For an AWS agent running on an EC2 instance:
         {
             "Action": [
                 "kinesis:DescribeStreamSummary",
-                "kinesis:ListTagsForStream",
-                "kinesis:ListStreams"
+                "kinesis:ListStreams",
+                "kinesis:ListTagsForStream"
             ],
             "Resource": "*",
             "Effect": "Allow",
@@ -327,13 +265,7 @@ For an AWS agent running on an EC2 instance:
         },
         {
             "Action": [
-                "apigateway:DELETE",
-                "apigateway:PUT",
-                "apigateway:HEAD",
-                "apigateway:PATCH",
-                "apigateway:POST",
-                "apigateway:GET",
-                "apigateway:OPTIONS"
+                "apigateway:GET"
             ],
             "Resource": "*",
             "Effect": "Allow",
@@ -341,8 +273,8 @@ For an AWS agent running on an EC2 instance:
         },
         {
             "Action": [
-                "cloudformation:DescribeStacks",
-                "cloudformation:DescribeStackResources"
+                "cloudformation:DescribeStackResources",
+                "cloudformation:DescribeStacks"
             ],
             "Resource": "*",
             "Effect": "Allow",
@@ -350,10 +282,9 @@ For an AWS agent running on an EC2 instance:
         },
         {
             "Action": [
-                "states:DescribeActivity",
-                "states:ListStateMachines",
                 "states:DescribeStateMachine",
                 "states:ListActivities",
+                "states:ListStateMachines",
                 "states:ListTagsForResource"
             ],
             "Resource": "*",

--- a/stackpacks/integrations/aws/aws.md
+++ b/stackpacks/integrations/aws/aws.md
@@ -140,14 +140,14 @@ To enable the AWS check and begin collecting data from AWS, add the following co
 
 #### Agent
 
-StackState Agent V2 must have access to the internet to call AWS APIs. If the Agent cannot be given direct internet access, a HTTP proxy can be used to proxy the API calls. [The AWS documentation (docs.aws.amazon.com)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html) outlines the variables that can be set. For more information on how to set environment variables for the Agent, see the [Agent documentation](/stackpacks/integrations/agent.md).
+StackState Agent V2 must have access to the internet to call AWS APIs. If the Agent cannot be given direct internet access, an HTTP proxy can be used to proxy the API calls. [The AWS documentation (docs.aws.amazon.com)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html) outlines the variables that can be set. For more information on how to set environment variables for the Agent, see the [Agent documentation](/stackpacks/integrations/agent.md).
 
 #### StackPack
 
 When an AWS StackPack instance is installed, the StackPack will test the provided credentials to AWS and fetch the alias of the AWS account. Also, the CloudWatch datasource will fetch CloudWatch metrics when a component is viewed. To proxy data for the StackPack, two methods can be used:
 
-- Use the environment variables specified in the [AWS documentation (docs.aws.amazon.com)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html). This will proxy only AWS data.
-- Pass the following properties when starting StackState instance `-Dhttp.proxyHost -Dhttp.proxyPort` and/or `-Dhttps.proxyHost -Dhttps.proxyPort`. This will proxy all data for the StackState instance.
+- To proxy only AWS data - use the environment variables specified in the [AWS documentation (docs.aws.amazon.com)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html).
+- To proxy all data for the StackState instance - pass the following properties when starting the StackState instance `-Dhttp.proxyHost -Dhttp.proxyPort` and/or `-Dhttps.proxyHost -Dhttps.proxyPort`.
 
 ### Status
 
@@ -299,7 +299,7 @@ A KMS key must be created in each region where events are captured.
 
 {% hint style="warning" %} VPC FlowLogs support is currently experimental and is disabled by default. {% endhint %}
 
-A VPC configured to send Flow Logs to the `stackstate-logs-${AccountId}` S3 bucket. The agent requires the AWS default format for VPC Flow Logs, and expects data to be aggregated every 1 minute.
+A VPC configured to send flow logs to the `stackstate-logs-${AccountId}` S3 bucket. The agent requires the AWS default format for VPC FlowLogs, and expects data to be aggregated every 1 minute.
 
 If configuring FlowLogs using CloudFormation, the `stackstate-resources` template exports the ARN of the S3 bucket it creates, so this can be imported into your template.
 

--- a/stackpacks/integrations/aws/aws.md
+++ b/stackpacks/integrations/aws/aws.md
@@ -229,6 +229,8 @@ Hourly and event-based updates collect data:
 - Hourly full topology updates - collected by the StackState Agent using an IAM role with access to the AWS services.
 - Event-based updates for single components and relations - captured using AWS services and placed into an S3 bucket for the StackState Agent to read.
 
+{% hint style="warning" %} VPC FlowLogs support is currently experimental and is disabled by default. {% endhint %}
+
 If the StackState Agent does not have permission to access a certain component, it will skip it.
 
 #### StackState Agent IAM Role

--- a/stackpacks/integrations/aws/aws.md
+++ b/stackpacks/integrations/aws/aws.md
@@ -102,7 +102,7 @@ Install the AWS StackPack from the StackState UI **StackPacks** &gt; **Integrati
 
 - **Role ARN** - the ARN of the IAM Role used to [deploy the AWS Cloudformation stack](#deploy-the-aws-cloudformation-stack). For example, `arn:aws:iam::<account id>:role/StackStateAwsIntegrationRole` where `<account id>` is the 12-digit AWS account ID.
 - **External ID** - a shared secret that StackState will present when assuming a role. Use the same value across all AWS accounts. For example, `uniquesecret!1`
-- **AWS Access Key ID** - The Access Key ID of the IAM user used by the StackState Agent. If the StackState instance is running within AWS, enter the value `use-role` the instance will authenticate using the attached IAM role.
+- **AWS Access Key ID** - The Access Key ID of the IAM user used by the StackState Agent. If the StackState instance is running within AWS, enter the value `use-role` and the instance will authenticate using the attached IAM role.
 - **AWS Secret Access Key** - The Secret Access Key of the IAM user used by the StackState Agent. If the StackState instance is running within AWS, enter the value `use-role` and the instance will authenticate using the attached IAM role.
 
 ### Configure the AWS check

--- a/stackpacks/integrations/aws/aws.md
+++ b/stackpacks/integrations/aws/aws.md
@@ -102,8 +102,8 @@ Install the AWS StackPack from the StackState UI **StackPacks** &gt; **Integrati
 
 - **Role ARN** - the ARN of the IAM Role used to [deploy the AWS Cloudformation stack](#deploy-the-aws-cloudformation-stack). For example, `arn:aws:iam::<account id>:role/StackStateAwsIntegrationRole` where `<account id>` is the 12-digit AWS account ID.
 - **External ID** - a shared secret that StackState will present when assuming a role. Use the same value across all AWS accounts. For example, `uniquesecret!1`
-- **AWS Access Key ID** - Optional. The Access Key ID of the IAM user used by the StackState Agent. If the StackState instance is running within AWS, leave empty and the instance will authenticate using the attached IAM role.
-- **AWS Secret Access Key** - Optional. The Secret Access Key of the IAM user used by the StackState Agent. If the StackState instance is running within AWS, leave empty and the instance will authenticate using the attached IAM role.
+- **AWS Access Key ID** - The Access Key ID of the IAM user used by the StackState Agent. If the StackState instance is running within AWS, enter the value `use-role` the instance will authenticate using the attached IAM role.
+- **AWS Secret Access Key** - The Secret Access Key of the IAM user used by the StackState Agent. If the StackState instance is running within AWS, enter the value `use-role` and the instance will authenticate using the attached IAM role.
 
 ### Configure the AWS check
 
@@ -138,11 +138,16 @@ To enable the AWS check and begin collecting data from AWS, add the following co
 
 ### Use an HTTP proxy
 
-StackState Agent V2 must have access to the internet to call the AWS APIs. If the Agent cannot be given direct internet access, an HTTP proxy can be used to proxy the API calls.
+#### Agent
 
-When an AWS StackPack instance is installed, the StackPack will test the provided credentials to AWS and fetch the alias of the AWS account. Also, the CloudWatch datasource will fetch CloudWatch metrics when a component is viewed. The same environment variables can be set for the main StackState instance to force all AWS traffic through an HTTP proxy.
+StackState Agent V2 must have access to the internet to call AWS APIs. If the Agent cannot be given direct internet access, a HTTP proxy can be used to proxy the API calls. [The AWS documentation (docs.aws.amazon.com)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html) outlines the variables that can be set. For more information on how to set environment variables for the Agent, see the [Agent documentation](/stackpacks/integrations/agent.md).
 
-To do so, [check this AWS doc (docs.aws.amazon.com)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html) and set the required environment variable on the machine or container running the Agent and StackState instance.
+#### StackPack
+
+When an AWS StackPack instance is installed, the StackPack will test the provided credentials to AWS and fetch the alias of the AWS account. Also, the CloudWatch datasource will fetch CloudWatch metrics when a component is viewed. To proxy data for the StackPack, two methods can be used:
+
+- Use the environment variables specified in the [AWS documentation (docs.aws.amazon.com)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html). This will proxy only AWS data.
+- Pass the following properties when starting StackState instance `-Dhttp.proxyHost -Dhttp.proxyPort` and/or `-Dhttps.proxyHost -Dhttps.proxyPort`. This will proxy all data for the StackState instance.
 
 ### Status
 
@@ -229,8 +234,6 @@ Hourly and event-based updates collect data:
 - Hourly full topology updates - collected by the StackState Agent using an IAM role with access to the AWS services.
 - Event-based updates for single components and relations - captured using AWS services and placed into an S3 bucket for the StackState Agent to read.
 
-{% hint style="warning" %} VPC FlowLogs support is currently experimental and is disabled by default. {% endhint %}
-
 If the StackState Agent does not have permission to access a certain component, it will skip it.
 
 #### StackState Agent IAM Role
@@ -291,6 +294,14 @@ A KMS key must be created in each region where events are captured.
 {% endhint %}
 
 - [Sample KMS Key policy](aws-policies.md#stackstate-integration-kms-key).
+
+#### VPC FlowLogs (Optional)
+
+{% hint style="warning" %} VPC FlowLogs support is currently experimental and is disabled by default. {% endhint %}
+
+A VPC configured to send Flow Logs to the `stackstate-logs-${AccountId}` S3 bucket. The agent requires the AWS default format for VPC Flow Logs, and expects data to be aggregated every 1 minute.
+
+If configuring FlowLogs using CloudFormation, the `stackstate-resources` template exports the ARN of the S3 bucket it creates, so this can be imported into your template.
 
 ### Costs
 

--- a/stackpacks/integrations/aws/aws.md
+++ b/stackpacks/integrations/aws/aws.md
@@ -114,8 +114,8 @@ To enable the AWS check and begin collecting data from AWS, add the following co
    ```yaml
    # values in init_config are used globally; these credentials will be used for all AWS accounts
    init_config:
-     aws_access_key_id: # The AWS Access Key ID. Optional if the Agent is running on an EC2 instance or ECS/EKS cluster with an IAM role
-     aws_secret_access_key: # The AWS Secret Access Key. Optional if the Agent is running on an EC2 instance or ECS/EKS cluster with an IAM role
+     aws_access_key_id: "" # The AWS Access Key ID. Leave empty quotes if the Agent is running on an EC2 instance or ECS/EKS cluster with an IAM role
+     aws_secret_access_key: "" # The AWS Secret Access Key. Leave empty quotes if the Agent is running on an EC2 instance or ECS/EKS cluster with an IAM role
      external_id: uniquesecret!1 # Set the same external ID when creating the CloudFormation stack in every account and region
 
    instances:
@@ -136,9 +136,13 @@ To enable the AWS check and begin collecting data from AWS, add the following co
 2. [Restart the StackState Agent](/setup/agent/about-stackstate-agent.md#run-stackstate-agent-v2) to apply the configuration changes.
 3. Once the Agent has restarted, wait for data to be collected from AWS and sent to StackState.
 
-### Use an HTTP proxy 
+### Use an HTTP proxy
 
-StackState Agent V2 must have access to the internet to call the AWS APIs. If the Agent cannot be given direct internet access, an HTTP proxy can be used to proxy the API calls. To do so, [check this AWS doc (docs.aws.amazon.com)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html) and set the required environment variable on the machine running the Agent.
+StackState Agent V2 must have access to the internet to call the AWS APIs. If the Agent cannot be given direct internet access, an HTTP proxy can be used to proxy the API calls.
+
+When an AWS StackPack instance is installed, the StackPack will test the provided credentials to AWS and fetch the alias of the AWS account. Also, the CloudWatch datasource will fetch CloudWatch metrics when a component is viewed. The same environment variables can be set for the main StackState instance to force all AWS traffic through an HTTP proxy.
+
+To do so, [check this AWS doc (docs.aws.amazon.com)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html) and set the required environment variable on the machine or container running the Agent and StackState instance.
 
 ### Status
 


### PR DESCRIPTION
- Update the IAM policy document with the latest changes
- Expand the proxy section to include information about setting the proxy in StackState itself
- Clarify that the access_key sections in the agent config should be left empty, not removed entirely