### PR TITLE
>> Merge after v4.4 is released! - Stac 44 after 44

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ description: StackState version 4.4
 # Welcome to the StackState Docs!
 
 {% hint style="success" %}
-**StackState version 4.4 is coming soon!**
+**StackState version 4.4** is now available - [check the release notes](setup/upgrade-stackstate/sts-release-notes.md#stackstate-v44x) for details.
+
+With the release of StackState v4.4, StackState v4.1 has reached End of Life \(EOL\) and will no longer be supported. We encourage customers still running the 4.1 version range to upgrade. Check the [supported StackState versions](#supported-stackstate-versions).
 {% endhint %}
 
 ### Using StackState


### PR DESCRIPTION
**Merge only after v4.4 docs are live.**

- Updates note box on front page to say "StackState v4.4 is available now".