### PR TITLE
456 release notes and base64 encoded trust stores

### DIFF
--- a/configure/security/self-signed-certificates.md
+++ b/configure/security/self-signed-certificates.md
@@ -97,6 +97,45 @@ stackstate/stackstate
 * The password and trust store are stored as a Kubernetes secret.
 {% endhint %}
 
+#### Base64 encoded trust stores
+
+If needed, the Java trust store can also be configured by passing Base64 encoded strings into Helm values.
+
+{% tabs %}
+{% tab title="Linux" %}
+
+To use a base64 encoded trust store, run the following `helm upgrade` command:
+
+```bash
+helm upgrade \
+  --install \
+  --namespace stackstate \
+  --values values.yaml \
+  --set 'stackstate.java.trustStoreBase64Encoded'=$(cat custom_cacerts | base64 -w0) \
+  --set 'stackstate.java.trustStorePassword'=changeit \
+stackstate \
+stackstate/stackstate
+```
+
+{% endtab %}
+{% tab title="MacOs" %}
+
+To use a base64 encoded trust store, run the following `helm upgrade` command:
+
+```bash
+helm upgrade \
+  --install \
+  --namespace stackstate \
+  --values values.yaml \
+  --set 'stackstate.java.trustStoreBase64Encoded'=$(cat custom_cacerts | base64) \
+  --set 'stackstate.java.trustStorePassword'=changeit \
+stackstate \
+stackstate/stackstate
+```
+
+{% endtab %}
+{% endtabs %}
+
 ### Linux
 
 For a Linux installation, the trust store and password need to be added to the JVM command line used to start the StackState server process.

--- a/setup/upgrade-stackstate/sts-release-notes.md
+++ b/setup/upgrade-stackstate/sts-release-notes.md
@@ -87,6 +87,17 @@ Details of the included improvements, bug fixes and StackPack updates can be fou
 
 Before you upgrade, [check the version specific upgrade instructions](/setup/upgrade-stackstate/version-specific-upgrade-instructions.md).
 
+### v4.5.6
+
+**Improvements**
+
+- Added support for base64 encoded trust stores. STAC-16004
+
+**Bug fixes**
+
+- If the OIDC configuration is wrongly configured to obtain a username, the logging will show all fields that can be selected to obtain the username from. STAC-16027
+- Security fixes for CVE-2022-24407. STAC-15939
+
 ### v4.5.5
 
 **Bug fixes**


### PR DESCRIPTION
ignore the branch name. this is not for the 462 release