### PR TITLE
STAC-0 APIs documentation improvements 

### DIFF
--- a/develop/reference/scripting/script-apis/async.md
+++ b/develop/reference/scripting/script-apis/async.md
@@ -4,15 +4,15 @@ description: StackState Self-hosted v5.0.x
 
 # Async - script API
 
-Some Script API functions are executed asynchronously and, instead of returning result directly, they return a `promise` of a result in the form of an `AsyncScriptResult`. The `Async` Script API offers functions to work with `AsyncScriptResult`.
+Async API offers top-level helper functions for working with [asynchronous script results](../async-script-result.md).
 
-## Function: `sequence`
+## Function: `Async.sequence(list: AsyncScriptResult[])`
 
 Flattens async results of Script API functions.
 
 ### Args
 
-* `list` - the list of `AsyncScriptResult`
+* `list` - a sequence of asynchronous script results.
 
 ### Examples
 

--- a/develop/reference/scripting/script-apis/component.md
+++ b/develop/reference/scripting/script-apis/component.md
@@ -4,7 +4,7 @@ description: StackState Self-hosted v5.0.x
 
 # Component - script API
 
-## Function: `withId`
+## Function: `Component.withId(id: Long)`
 
 Get access to a component by its ID.
 

--- a/develop/reference/scripting/script-apis/http.md
+++ b/develop/reference/scripting/script-apis/http.md
@@ -10,7 +10,7 @@ Sometimes it may be useful to process the retrieved topology or telemetry data u
 The permission `execute-restricted-scripts` is required to execute scripts using the HTTP script API in the StackState UI analytics environment. For details, see the [analytics page permissions](../../../../configure/security/rbac/rbac_permissions.md#analytics-page-permissions).
 {% endhint %}
 
-## Function: `get`
+## Function: `HTTP.get(uri: String)`
 
 Submit HTTP get request.
 
@@ -37,7 +37,7 @@ Http.get("https://www.google.com/?q=apples")
     .header("name", "value")
 ```
 
-## Function: `put`
+## Function: `HTTP.put(uri: String)`
 
 Submit HTTP put request.
 
@@ -72,7 +72,7 @@ Http.put("http://http_server:8080/api")
   .jsonResponse()
 ```
 
-## Function: `post`
+## Function: `HTTP.post(uri: String)`
 
 Submit HTTP post request.
 
@@ -111,7 +111,7 @@ Http.post("http://http_server:8080/api")
 }.jsonBody()
 ```
 
-## Function: `delete`
+## Function: `HTTP.delete(uri: String)`
 
 Submit HTTP delete request.
 
@@ -138,9 +138,15 @@ Http.delete("http://http_server:8080/api")
     .header("name", "value")
 ```
 
-## Function: `options`
+## Function: `HTTP.options(uri: String)`
 
 Submit HTTP options request.
+
+### Args
+
+* `uri` - uri of the HTTP server.
+
+### Examples
 
 ```text
 Http.options("http://http_server:8080/api")
@@ -149,7 +155,7 @@ Http.options("http://http_server:8080/api")
     .header("name", "value")
 ```
 
-## Function: `patch`
+## Function: `HTTP.patch(uri: String)`
 
 Submit HTTP patch request.
 
@@ -182,7 +188,7 @@ Http.patch("http://http_server:8080/api")
     .textRequest("{'property', 'value'}")
 ```
 
-## Function: `head`
+## Function: `HTTP.head(uri: String)`
 
 Submit HTTP head request.
 

--- a/develop/reference/scripting/script-apis/prediction.md
+++ b/develop/reference/scripting/script-apis/prediction.md
@@ -4,7 +4,7 @@ description: StackState Self-hosted v5.0.x
 
 # Prediction - script API
 
-## Function: `predictMetrics`
+## Function: `Prediction.predictMetrics(predictorName: String, horizon: Duration, query: String)`
 
 Predict metrics for any metric query coming from any data source.
 

--- a/develop/reference/scripting/script-apis/stackpack.md
+++ b/develop/reference/scripting/script-apis/stackpack.md
@@ -6,7 +6,7 @@ description: StackState Self-hosted v5.0.x
 
 The StackPack script API provides handy operations to get the status of a StackPack or resources that are provided by a StackPack.
 
-## Function: `isInstalled`
+## Function: `StackPack.isInstalled(name: String)`
 
 Returns a flag indicating if the StackPack is installed
 
@@ -45,7 +45,7 @@ The example below will return an `AsyncScriptResult` of a boolean indicating if 
 StackPack.isInstalled("agent")
 ```
 
-## Function: `getResources`
+## Function: `StackPack.getResources(stackPackNamespace: String, nodeType: String)`
 
 Returns resources originating from the StackPack.
 

--- a/develop/reference/scripting/script-apis/telemetry.md
+++ b/develop/reference/scripting/script-apis/telemetry.md
@@ -4,13 +4,9 @@ description: StackState Self-hosted v5.0.x
 
 # Telemetry - script API
 
-## Function: `query`
+## Function: `Telemetry.query(dataSourceName: String, query: String)`
 
 A telemetry query is a conjunction of equality conditions. For example, `name = 'system.load.norm.15' and host='localhost'`. There are several builder methods available that help to refine the query time range, limit the number of points returned, or set a metric field.
-
-```text
-Telemetry.query(dataSourceName: String, query: String)
-```
 
 {% hint style="warning" %}
 Telemetry queries only support metric queries. If you need event queries, please enter a feature request at [support.stackstate.com](https://support.stackstate.com)
@@ -18,7 +14,7 @@ Telemetry queries only support metric queries. If you need event queries, please
 
 ### Args
 
-* `dataSourceName` - name of the data source.
+* `dataSourceNam` - name of the data source.
 * `query` - set of equality conditions.
 
 ### Returns

--- a/develop/reference/scripting/script-apis/telemetry.md
+++ b/develop/reference/scripting/script-apis/telemetry.md
@@ -14,7 +14,7 @@ Telemetry queries only support metric queries. If you need event queries, please
 
 ### Args
 
-* `dataSourceNam` - name of the data source.
+* `dataSourceName` - name of the data source.
 * `query` - set of equality conditions.
 
 ### Returns

--- a/develop/reference/scripting/script-apis/time.md
+++ b/develop/reference/scripting/script-apis/time.md
@@ -6,7 +6,7 @@ description: StackState Self-hosted v5.0.x
 
 Time API offers helper functions to manipulate with [time type](../time-in-scripts.md) in StackState scripts.
 
-## Function: `currentTimeSlice()`
+## Function: `Time.currentTimeSlice()`
 
 Returns a time slice for the current timestamp
 
@@ -26,7 +26,7 @@ Time.currentTimeSlice().then { slice ->
 }
 ```
 
-## Function: `format(instant, pattern)`
+## Function: `Time.format(instant: Instant, pattern: String)`
 
 Format an instant to string using the given formatting pattern
 
@@ -43,7 +43,7 @@ Format an instant to ISO 8601 time
 Time.format(1577966400000, "yyyy-MM-dd'T'HH:mm:ss'Z'")
 ```
 
-## Function: `epochMs(instant)`
+## Function: `Time.epochMs(instant: Instant)`
 
 ### Args
 

--- a/develop/reference/scripting/script-apis/topology.md
+++ b/develop/reference/scripting/script-apis/topology.md
@@ -6,13 +6,9 @@ description: StackState Self-hosted v5.0.x
 
 # Topology - script API
 
-## Function: `query`
+## Function: `Topology.query(query: String)`
 
 Query the topology at any point in time. Builder methods available for extracting components, relations and comparing topological queries.
-
-```text
-Topology.query(query: String)
-```
 
 ### Args
 

--- a/develop/reference/scripting/script-apis/ui.md
+++ b/develop/reference/scripting/script-apis/ui.md
@@ -8,7 +8,7 @@ description: StackState Self-hosted v5.0.x
 These functions only work in the context of scripts that are executed by a user from the user-interface. [Component actions](../../../../configure/topology/component_actions.md) are an example of scripts that can trigger actions in the user-interface.
 {% endhint %}
 
-## Function: baseUrl
+## Function: `UI.baseUrl()`
 
 Returns the baseUrl of the StackState instance (`<STACKSTATE_BASE_URL>`) as configured in the `application.conf` or `values.yaml`.
 
@@ -16,11 +16,7 @@ Returns the baseUrl of the StackState instance (`<STACKSTATE_BASE_URL>`) as conf
 
 Return the base URL from the StackState configuration.
 
-```groovy
-UI.baseUrl()
-```
-
-## Function: `createUrl`
+## Function: `UI.createUrl()`
 
 Creates a URL builder that can be used to generate URLs that can be linked back in StackState.
 
@@ -89,7 +85,7 @@ Create a URL to the Topology Perspective explore mode with filters in place to s
 UI.createUrl().explore().topologyQuery('environment IN ("Production") AND healthstate IN ("CRITICAL")').fullCauseTree().url()
 ```
 
-## Function: `redirectToURL`
+## Function: `UI.redirectToURL(url: String)`
 
 Opens a new tab in the user's browser to some URL.
 
@@ -109,7 +105,7 @@ Open the stackstate.com website in a new tab in the browser.
 UI.redirectToURL("http://wwww.stackstate.com")
 ```
 
-## Function: `showReport`
+## Function: `UI.showReport(reportName: String, stmlContent: String)`
 
 Shows a report in the user-interface. The user-interface will open a dialog with the report in it. You can also see the result of these reports in the preview of the analytics environment.
 
@@ -140,7 +136,7 @@ UI.showReport(
 
 Note the `.stripMargin()` call. This is a Groovy function for strings that strips leading whitespace/control characters followed by '\|' from every line. This way, indenting can be retained without introducing leading whitespace in the STML.
 
-## Function: `showTopologyByQuery`
+## Function: `UI.showTopologyByQuery(query: String)`
 
 Sets the user-interface to the Topology Perspective and changes the SQTL query.
 

--- a/develop/reference/scripting/script-apis/view.md
+++ b/develop/reference/scripting/script-apis/view.md
@@ -4,7 +4,7 @@ description: StackState Self-hosted v5.0.x
 
 # View - script API
 
-## Function: `getAll`
+## Function: `View.getAll()`
 
 Returns a list of all views.
 
@@ -56,7 +56,7 @@ View.getAll()
     }
 ```
 
-## Function: `withId(viewId).problems()`
+## Function: `View.withId(viewId).problems()`
 
 Returns a list of all problems in a view.
 
@@ -97,9 +97,9 @@ The example below returns the name of the root cause component of the first prob
 
 ```yaml
 View
-    .withId(230470072729670)  
+    .withId(230470072729670)
     .problems()
-        .then{ problems ->       
+    .then { problems ->
         problems.isEmpty()? null : 
             problems[0].rootCause.causeName + " - failed check(s): " +
             problems[0].rootCause.failingCheckNames


### PR DESCRIPTION
@gggina it's just a proposal for APIs documentation improvements.

I've updated all the function names to follow the pattern `API.function(arg1: Type)`. This notation can be easily copied from the documentation and used without extra modifications. While the addition of type hints for arguments is aimed to help the user chose correct params and avoid type mismatch errors. 