### PR TITLE
Fixup ES restore scaling commands

### DIFF
--- a/setup/data-management/backup_restore/kubernetes_backup.md
+++ b/setup/data-management/backup_restore/kubernetes_backup.md
@@ -354,9 +354,9 @@ To delete existing Elasticsearch indices so that a snapshot can be restored, fol
 1. Stop indexing - scale down all `*2es` deployments to 0:
 
    ```bash
-   kubectl scale --replicas=0 deployment/e2es
-   kubectl scale --replicas=0 deployment/mm2es
-   kubectl scale --replicas=0 deployment/trace2es
+   kubectl scale --replicas=0 deployment/stackstate-e2es
+   kubectl scale --replicas=0 deployment/stackstate-mm2es
+   kubectl scale --replicas=0 deployment/stackstate-trace2es
    ```
 
 2. Open a port-forward to the Elasticsearch master:
@@ -447,7 +447,7 @@ The indices restored are listed in the output, as well as the number of failed a
 After the indices have been restored, scale up all `*2es` deployments:
 
    ```bash
-   kubectl scale --replicas=1 deployment/e2es
-   kubectl scale --replicas=1 deployment/mm2es
-   kubectl scale --replicas=1 deployment/trace2es
+   kubectl scale --replicas=1 deployment/stackstate-e2es
+   kubectl scale --replicas=1 deployment/stackstate-mm2es
+   kubectl scale --replicas=1 deployment/stackstate-trace2es
    ```


### PR DESCRIPTION
As the docs mentioned, some Deployments need to be scaled down before restoring from an ES snapshot. The scaling commands errored on a try on release 5.1.8. The Deployment names mismatched.

PR for changing the Deployment names in the docs. Assuming the default value for fullname used in the Chart.