### PR TITLE
Update k8s-suse-rancher-prime.md

### DIFF
--- a/k8s-suse-rancher-prime.md
+++ b/k8s-suse-rancher-prime.md
@@ -74,6 +74,7 @@ Before installing the StackState server a default storage class must be set up i
 - **For k3s**: The local-path storage class of type rancher.io/local-path is created by default.
 - **For EKS, AKS, GKE** a storage class is set by default
 - **For RKE2 Node Drivers**: No storage class is created by default. You will need to create one before installing StackState.
+- **RKE1** is not supported to run StackState server.
 
 ## Installing StackState
 


### PR DESCRIPTION
Added the fact that RKE1 is not supported as cluster to run StackState server. In relation to: https://stackstate.atlassian.net/browse/STAC-21618